### PR TITLE
Add support for static labels in queries.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,24 @@ The specified queries in the configuration file will be exporter with two labels
 - `repo` - the repository that the query was executed against
 - `interval` - the interval the query result represent.
 
-Here is an example.
+There is an option to add static labels as well. This can be done as follows:
+
+```
+- query: sum(status)
+  repo: humio
+  interval: 30m
+  metric_name: humio_status_sum
+  metric_labels:
+  - key: squad
+    value: nasa
+```
+
+Example.
 
 ```
 humio_total{interval="5m", repo="humio"} 3458
 humio_audit_total{interval="5m", repo="humio-audit"} 2976
+humio_status_sum{interval="30m", repo="humio", squad="nasa"} 235
 ```
 
 # Build

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ queries:
   - key: squad
     value: nasa
 ```
-As seen in the last example query, you can also specify at set of static labels to be outputtet along with the metric.
+As seen in the last example query, you can also specify a set of static labels to be outputtet along with the metric.
 
 Currently the export supports the above aggregate query functions
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,12 @@ queries:
   repo: humio
   interval: 30m
   metric_name: humio_status_sum
+  metric_labels:
+  - key: squad
+    value: nasa
 ```
+As seen in the last example query, you can also specify at set of static labels to be outputtet along with the metric.
+
 Currently the export supports the above aggregate query functions
 
 ```

--- a/examples/queries.yaml
+++ b/examples/queries.yaml
@@ -38,6 +38,9 @@ queries:
   repo: humio
   interval: 30m
   metric_name: humio_status_sum
+  metric_labels:
+  - key: squad
+    value: nasa
 
 
 

--- a/humio.go
+++ b/humio.go
@@ -25,7 +25,7 @@ type startQueryPayload struct {
 	IsLive      bool   `json:"isLive"`
 }
 
-func (c *client) startQueryJob(query, repo, metricName, start, end string) (queryJob, error) {
+func (c *client) startQueryJob(query, repo, metricName, start, end string, labels []MetricLabel) (queryJob, error) {
 	postData := startQueryPayload{
 		QueryString: query,
 		Start:       start,
@@ -57,6 +57,7 @@ func (c *client) startQueryJob(query, repo, metricName, start, end string) (quer
 	queryResponse.Timespan = start
 	queryResponse.Repo = repo
 	queryResponse.MetricName = metricName
+	queryResponse.MetricLabels = labels
 
 	return queryResponse, nil
 }

--- a/main.go
+++ b/main.go
@@ -18,10 +18,11 @@ import (
 )
 
 type queryJob struct {
-	Id         string
-	Timespan   string
-	Repo       string
-	MetricName string
+	Id           string
+	Timespan     string
+	Repo         string
+	MetricName   string
+	MetricLabels []MetricLabel
 }
 
 type queryJobData struct {
@@ -39,11 +40,17 @@ type MetricMap struct {
 
 type YamlConfig struct {
 	Queries []struct {
-		Query      string `yaml:"query"`
-		Repo       string `yaml:"repo"`
-		Interval   string `yaml:"interval"`
-		MetricName string `yaml:"metric_name"`
+		Query        string        `yaml:"query"`
+		Repo         string        `yaml:"repo"`
+		Interval     string        `yaml:"interval"`
+		MetricName   string        `yaml:"metric_name"`
+		MetricLabels []MetricLabel `yaml:"metric_labels"`
 	} `yaml:"queries"`
+}
+
+type MetricLabel struct {
+	Key   string `yaml:"key"`
+	Value string `yaml:"value"`
 }
 
 var (
@@ -91,7 +98,7 @@ func main() {
 	}
 
 	for _, q := range yamlConfig.Queries {
-		metricMap.AddGauge(q.MetricName, q.Repo, q.Interval)
+		metricMap.AddGauge(q.MetricName, q.MetricLabels)
 	}
 
 	err = metricMap.Register()
@@ -142,7 +149,7 @@ func runAPIPolling(done chan error, url, token string, yamlConfig YamlConfig, re
 	var jobs []queryJob
 
 	for _, q := range yamlConfig.Queries {
-		job, err := client.startQueryJob(q.Query, q.Repo, q.MetricName, q.Interval, "now")
+		job, err := client.startQueryJob(q.Query, q.Repo, q.MetricName, q.Interval, "now", q.MetricLabels)
 		if err != nil {
 			done <- err
 			return
@@ -185,7 +192,7 @@ func runAPIPolling(done chan error, url, token string, yamlConfig YamlConfig, re
 			}
 
 			if poll.Done {
-				metricMap.UpdateMetricValue(job.MetricName, job.Timespan, job.Repo, floatValue)
+				metricMap.UpdateMetricValue(job.MetricName, job.Timespan, job.Repo, floatValue, job.MetricLabels)
 				if err != nil {
 					done <- err
 					return
@@ -212,17 +219,32 @@ func (m *MetricMap) Register() error {
 	return nil
 }
 
-func (m *MetricMap) UpdateMetricValue(metricName, timespan, repo string, value float64) error {
+func (m *MetricMap) UpdateMetricValue(metricName, timespan, repo string, value float64, labels []MetricLabel) error {
+
+	stringMap := make(map[string]string)
+	stringMap[intervalLabel] = timespan
+	stringMap[repoLabel] = repo
+	for _, l := range labels {
+		stringMap[l.Key] = l.Value
+	}
+
 	gauge := m.Gauges[metricName]
-	gauge.WithLabelValues(timespan, repo).Set(value)
+	gauge.With(stringMap).Set(value)
 	return nil
 }
 
-func (m *MetricMap) AddGauge(metricName, repo, interval string) error {
+func (m *MetricMap) AddGauge(metricName string, labels []MetricLabel) error {
+	var labelSlice []string
+	labelSlice = append(labelSlice, intervalLabel)
+	labelSlice = append(labelSlice, repoLabel)
+	for _, l := range labels {
+		labelSlice = append(labelSlice, l.Key)
+	}
+
 	m.Gauges[metricName] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: metricName,
 			Help: "Gauge for humio query",
-		}, []string{intervalLabel, repoLabel})
+		}, labelSlice)
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -219,32 +219,32 @@ func (m *MetricMap) Register() error {
 	return nil
 }
 
-func (m *MetricMap) UpdateMetricValue(metricName, timespan, repo string, value float64, labels []MetricLabel) error {
+func (m *MetricMap) UpdateMetricValue(metricName, timespan, repo string, value float64, staticLabels []MetricLabel) error {
 
-	stringMap := make(map[string]string)
-	stringMap[intervalLabel] = timespan
-	stringMap[repoLabel] = repo
-	for _, l := range labels {
-		stringMap[l.Key] = l.Value
+	labels := make(map[string]string)
+	labels[intervalLabel] = timespan
+	labels[repoLabel] = repo
+	for _, l := range staticLabels {
+		labels[l.Key] = l.Value
 	}
 
 	gauge := m.Gauges[metricName]
-	gauge.With(stringMap).Set(value)
+	gauge.With(labels).Set(value)
 	return nil
 }
 
-func (m *MetricMap) AddGauge(metricName string, labels []MetricLabel) error {
-	var labelSlice []string
-	labelSlice = append(labelSlice, intervalLabel)
-	labelSlice = append(labelSlice, repoLabel)
-	for _, l := range labels {
-		labelSlice = append(labelSlice, l.Key)
+func (m *MetricMap) AddGauge(metricName string, staticLabels []MetricLabel) error {
+	var labelKeys []string
+	labelKeys = append(labelKeys, intervalLabel)
+	labelKeys = append(labelKeys, repoLabel)
+	for _, l := range staticLabels {
+		labelKeys = append(labelKeys, l.Key)
 	}
 
 	m.Gauges[metricName] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: metricName,
 			Help: "Gauge for humio query",
-		}, labelSlice)
+		}, labelKeys)
 	return nil
 }


### PR DESCRIPTION
This PR fixes #3 by adding support for specifying static labels that you want to be present in the resulting prometheus metric.

This can be done by adding med `metric_labels` array in queries.yaml as follows:

```
- query: sum(status)
  repo: humio
  interval: 30m
  metric_name: humio_status_sum
  metric_labels:
  - key: squad
    value: nasa
```