### PR TITLE
Upgrade to Go 1.17.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- "1.16.x"
+- "1.17.x"
 script:
 - go build ./...
 - go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5 as builder
+FROM golang:1.17.2 as builder
 WORKDIR /src
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,25 @@
 module github.com/lunarway/humio_exporter
 
-go 1.16
+go 1.17
 
 require (
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/common v0.25.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/sirupsen/logrus v1.6.0 // indirect
+	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 // indirect
+	google.golang.org/protobuf v1.23.0 // indirect
 )


### PR DESCRIPTION
This change upgrades the exporter to Go 1.17 which also adds changes to the
go.mod file format. The changes to go.mod is from:

    go mod tidy -go=1.17