### PR TITLE
Remove release action guard to make release action run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     # only allow tags on the master branch
-    if: github.event.release.target_commitish == 'master'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The latest release failed to run. This contains the fix to enable it.