### PR TITLE
Fix panic for case when no metrics are returned

### DIFF
--- a/main.go
+++ b/main.go
@@ -179,6 +179,12 @@ func runAPIPolling(done chan error, url, token string, yamlConfig YamlConfig, re
 				return
 			}
 
+			// Handle cases where the metric may be missing for the given time range
+			if len(poll.Events) < 1 {
+				zap.L().Sugar().Debugf("No Events returned by query. Timespan: %v, MetricName: %s", job.Timespan, job.MetricName)
+				continue
+			}
+
 			var floatValue float64
 			for _, f := range supportedFunctions {
 				value, ok := poll.Events[0][f]

--- a/main.go
+++ b/main.go
@@ -201,7 +201,6 @@ func runAPIPolling(done chan error, url, token string, yamlConfig YamlConfig, re
 				}
 			} else {
 				zap.L().Sugar().Debugf("Skipped value because query isn't done. Timespan: %v, Value: %v", job.Timespan, floatValue)
-
 			}
 		}
 		time.Sleep(5000 * time.Millisecond)
@@ -223,7 +222,6 @@ func (m *MetricMap) Register() error {
 }
 
 func (m *MetricMap) UpdateMetricValue(metricName, timespan, repo string, value float64, staticLabels []MetricLabel) error {
-
 	labels := make(map[string]string)
 	labels[intervalLabel] = timespan
 	labels[repoLabel] = repo


### PR DESCRIPTION
Hello!

Thank you for creating this project, it's been helpful for monitoring our Humio clusters. However I did notice a panic for cases where some more complex queries might not have a metric for a particular timespan. In this case the exporter would panic when trying access the Events array at element 0.

I've introduced a fix which will simply continue for this particular case and have verified it in my own environment.

Please let me know if I can assist with getting this merged ASAP.

Much appreciated!