### PR TITLE
Add Table-Based Metrics with Dynamic Labels Support

### DIFF
--- a/examples/queries.yaml
+++ b/examples/queries.yaml
@@ -41,3 +41,19 @@ queries:
     metric_labels:
       - key: squad
         value: foo
+
+  - query: eventSize() | groupBy("k8s.labels.app", function=sum(_eventSize, as="value"))
+    # Results in a table like this:
+    # | k8s.labels.app | value |
+    # |----------------|-------|
+    # | foo            | 100   |
+    # | bar            | 200   |
+    repo: humio
+    interval: 1h
+    metric_name: log_ingest_bytes
+    metric_labels:
+    - key: app
+      valueFromTable: k8s.labels.app
+    # This will result in the following metric:
+    # log_ingest_bytes{app="foo", interval="1h", repo="humio"} 100
+    # log_ingest_bytes{app="bar", interval="1h", repo="humio"} 200

--- a/humio.go
+++ b/humio.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 )
 
-type Client struct {
+type client struct {
 	httpClient *http.Client
 	token      string
 	baseURL    string
@@ -25,7 +25,7 @@ type startQueryPayload struct {
 	IsLive      bool   `json:"isLive"`
 }
 
-func (c *Client) startQueryJob(query, repo, metricName, start, end string, labels []MetricLabel) (queryJob, error) {
+func (c *client) startQueryJob(query, repo, metricName, start, end string, labels []MetricLabel) (queryJob, error) {
 	postData := startQueryPayload{
 		QueryString: query,
 		Start:       start,
@@ -62,7 +62,7 @@ func (c *Client) startQueryJob(query, repo, metricName, start, end string, label
 	return queryResponse, nil
 }
 
-func (c *Client) stopQueryJob(id, repo string) error {
+func (c *client) stopQueryJob(id, repo string) error {
 	req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/repositories/%s/queryjobs/%s", c.baseURL, repo, id), nil)
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (c *Client) stopQueryJob(id, repo string) error {
 	return nil
 }
 
-func (c *Client) pollQueryJob(id, repo string) (queryJobData, error) {
+func (c *client) pollQueryJob(id, repo string) (queryJobData, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/repositories/%s/queryjobs/%s", c.baseURL, repo, id), nil)
 	if err != nil {
 		return queryJobData{}, err
@@ -94,7 +94,7 @@ func (c *Client) pollQueryJob(id, repo string) (queryJobData, error) {
 	return queryJobDataResponse, nil
 }
 
-func (c *Client) do(req *http.Request) (*http.Response, error) {
+func (c *client) do(req *http.Request) (*http.Response, error) {
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.token))
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")

--- a/humio.go
+++ b/humio.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 )
 
-type client struct {
+type Client struct {
 	httpClient *http.Client
 	token      string
 	baseURL    string
@@ -25,7 +25,7 @@ type startQueryPayload struct {
 	IsLive      bool   `json:"isLive"`
 }
 
-func (c *client) startQueryJob(query, repo, metricName, start, end string, labels []MetricLabel) (queryJob, error) {
+func (c *Client) startQueryJob(query, repo, metricName, start, end string, labels []MetricLabel) (queryJob, error) {
 	postData := startQueryPayload{
 		QueryString: query,
 		Start:       start,
@@ -62,7 +62,7 @@ func (c *client) startQueryJob(query, repo, metricName, start, end string, label
 	return queryResponse, nil
 }
 
-func (c *client) stopQueryJob(id, repo string) error {
+func (c *Client) stopQueryJob(id, repo string) error {
 	req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/repositories/%s/queryjobs/%s", c.baseURL, repo, id), nil)
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (c *client) stopQueryJob(id, repo string) error {
 	return nil
 }
 
-func (c *client) pollQueryJob(id, repo string) (queryJobData, error) {
+func (c *Client) pollQueryJob(id, repo string) (queryJobData, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/repositories/%s/queryjobs/%s", c.baseURL, repo, id), nil)
 	if err != nil {
 		return queryJobData{}, err
@@ -94,7 +94,7 @@ func (c *client) pollQueryJob(id, repo string) (queryJobData, error) {
 	return queryJobDataResponse, nil
 }
 
-func (c *client) do(req *http.Request) (*http.Response, error) {
+func (c *Client) do(req *http.Request) (*http.Response, error) {
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.token))
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func main() {
 }
 
 func runAPIPolling(done chan error, url, token string, yamlConfig YamlConfig, requestTimeout time.Duration, metricMap MetricMap) {
-	client := Client{
+	client := client{
 		httpClient: &http.Client{
 			Timeout: requestTimeout,
 		},


### PR DESCRIPTION
⚠️ This is a public repository.

Implements support for table-based queries that return multiple rows, enabling the use of groupBy() and similar functions. Each row can be exported as a separate Prometheus metric with dynamic labels derived from table columns.

## Key Changes

- Added valueFromTable field to MetricLabel for dynamic labels from table columns
- New UpdateMetricValueFromTable() function processes table results
- Null value handling (sets to "unknown" for consistent cardinality)
- There should be no breaking changes. Existing configurations should continue to work unchanged.

## Example
See updated README.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add table-based query support that emits per-row metrics with dynamic labels from table columns, plus docs/examples and minor client export refactor.
> 
> - **Exporter (runtime)**:
>   - Add table-based processing: new `MetricMap.UpdateMetricValueFromTable` to emit per-row metrics from `poll.Events`.
>   - Dynamic labels via `MetricLabel.ValueFromTable`; empty/NULL values default to `"unknown"`.
>   - `runAPIPolling`: detect table-label configs and route to table processing; keep existing single-value flow; improved debug log.
> - **API/Types**:
>   - Extend `MetricLabel` with `valueFromTable` (preserve `key`/`value`).
>   - Skip setting empty static label values in `UpdateMetricValue`.
>   - Rename `client` to exported `Client` and update method receivers/usage.
> - **Docs/Examples**:
>   - README: new section on table-based metrics with example and null-handling notes.
>   - `examples/queries.yaml`: add table-based query example using `valueFromTable`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dda067792b94802189ecfabf92ab51fda93c419c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->