### PR TITLE
Improve resiliency on 404 responses

### DIFF
--- a/humio.go
+++ b/humio.go
@@ -122,6 +122,9 @@ func (c *client) do(req *http.Request) (*http.Response, error) {
 
 		response, err = c.httpClient.Do(req)
 		if err != nil || (response != nil && response.StatusCode >= 500) {
+			if response != nil && response.Body != nil {
+				response.Body.Close()
+			}
 			zap.L().Sugar().Warnf("Request failed (attempt %d/3), retrying: %v", attempt+1, err)
 			time.Sleep(time.Duration(attempt+1) * time.Second)
 			continue

--- a/main.go
+++ b/main.go
@@ -204,6 +204,8 @@ func runAPIPolling(done chan error, url, token string, yamlConfig YamlConfig, re
 				// If query job not found (expired), restart it
 				if errors.Is(err, ErrQueryNotFound) {
 					zap.L().Sugar().Infof("Query job %s expired, restarting for metric %s", job.Id, job.MetricName)
+					// Try to stop old query job first, ignore errors since it may not exist
+					client.stopQueryJob(job.Id, job.Repo)
 					cfg := configs[i]
 					newJob, restartErr := client.startQueryJob(cfg.Query, cfg.Repo, cfg.MetricName, cfg.Interval, "now", cfg.MetricLabels)
 					if restartErr != nil {


### PR DESCRIPTION
To make humio_exporter more resilient, I've made some changes, so it doesn't crash on all 404 or 5xx responses.

- For 404s: We now detect ErrQueryNotFound and restart the query job instead of sending to done (triggering crashing)
- For 5xx: We now retry up to 3 times before giving up, so transient server errors don't cause immediate crashes

Part of ESA-1044