### PR TITLE
Delete stale metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -265,6 +265,17 @@ func (m *MetricMap) UpdateMetricValue(metricName, timespan, repo string, value f
 }
 
 func (m *MetricMap) UpdateMetricValueFromTable(metricName, timespan, repo string, tableData []map[string]interface{}, metricLabels []MetricLabel) error {
+	gauge := m.Gauges[metricName]
+
+	// Evict series from the previous poll that share this (repo, interval) scope so
+	// label values that no longer appear in the query result stop being exported.
+	// Scoping by repo+interval avoids clobbering series produced by other queries
+	// that happen to share the same metric name.
+	gauge.DeletePartialMatch(prometheus.Labels{
+		repoLabel:     repo,
+		intervalLabel: timespan,
+	})
+
 	for _, row := range tableData {
 		labels := make(map[string]string)
 		labels[intervalLabel] = timespan
@@ -328,7 +339,6 @@ func (m *MetricMap) UpdateMetricValueFromTable(metricName, timespan, repo string
 			continue
 		}
 
-		gauge := m.Gauges[metricName]
 		gauge.With(labels).Set(floatValue)
 	}
 	return nil


### PR DESCRIPTION
[Public Repository]

### Problem
Stale label series are never deleted. This means that even if they are not in the query result they can be scraped by Prometheus. It will appear as if the labels series has its last know value for the remaining duration of the exporters lifecycle (until restarted or terminated). This results in misleading metrics.

### Solution
The solution here is to delete old metrics from the GaugeVec before repopulating it with the updated query result.

### Special Behavior
This solution is simple, but results in a known edge case: if metrics are scraped between `gauge.DeletePartialMatch` and `gauge.With.Set` the result will not contain the updated label series nor the previous label series. This behavior is accepted given the simplicity of the fix and the low risk of a scrape happening exactly in that during the update (assumes scrape every 15-30 s and update taking <1 ms).

Fixes ESA-2165.